### PR TITLE
Fixed typo on tooltip for help icon

### DIFF
--- a/headers-form-editor-item.html
+++ b/headers-form-editor-item.html
@@ -212,7 +212,7 @@ Custom property | Description | Default
       <template is="dom-if" if="[[item.description]]">
         <span>
           <paper-icon-button class="help-icon" icon="arc:help" on-tap="openDescription"></paper-icon-button>
-          <paper-tooltip animation-delay="200">Show dosumentation for the header</paper-tooltip>
+          <paper-tooltip animation-delay="200">Show documentation for the header</paper-tooltip>
         </span>
       </template>
     </div>


### PR DESCRIPTION
I found a typo as above on the tooltip for the help icon - dosumentation -> documentation  :)
